### PR TITLE
Support user token instead of service token

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ export type Action =
   | { type: "saveWorkbench"; payload: string | undefined }
   | { type: "loadWorkbench"; payload: string | undefined }
   | { type: "refreshComposition" }
-;
+  | { type: "loadFromAGM"; payload: { services: { [name: string]: string } } };
 
 type State = {
   services: { [name: string]: string };
@@ -61,14 +61,14 @@ const reducer: Reducer<State, Action> = (state, action) => {
       // Exit on blank-ish service name (EMOJIIS WORK, THOUGH 👍)
       if (action.payload.name.trim().length === 0) return state;
       const selectedService = state.selectedService || action.payload.name;
-        return {
-          ...state,
-          selectedService,
-          services: {
-            ...state.services,
-            [action.payload.name.trim()]: "",
-          },
-        };
+      return {
+        ...state,
+        selectedService,
+        services: {
+          ...state.services,
+          [action.payload.name.trim()]: "",
+        },
+      };
     }
     case "selectService": {
       return {
@@ -176,6 +176,15 @@ const reducer: Reducer<State, Action> = (state, action) => {
       // Okay, we have a serializeable Redux store.
 
       return { ...state, ...hopefullyValidState };
+    }
+    case "loadFromAGM": {
+      return {
+        ...state,
+        query: undefined,
+        queryPlan: "",
+        selectedService: undefined,
+        services: action.payload.services,
+      };
     }
   }
 };

--- a/src/LoadFromAgm.tsx
+++ b/src/LoadFromAgm.tsx
@@ -9,15 +9,25 @@ type Props = {
   dispatch: Dispatch<Action>;
 };
 
-const variantsQuery = gql`
-  query TrevorDoingStuff {
+const graphSelectQuery = gql`
+  query GraphSelectQuery {
     me {
-      ... on Service {
-        createdAt
-        schemaTags {
-          variant {
-            name
+      id
+      ... on User {
+        memberships {
+          account {
             id
+            name
+            services {
+              id
+              name
+              schemaTags {
+                variant {
+                  id
+                  name
+                }
+              }
+            }
           }
         }
       }
@@ -26,16 +36,14 @@ const variantsQuery = gql`
 `;
 
 const partialSdlQuery = gql`
-  query Trevor2($graphVariant: String!) {
-    me {
-      ... on Service {
-        implementingServices(graphVariant: $graphVariant) {
-          ... on FederatedImplementingServices {
-            services {
-              name
-              activePartialSchema {
-                sdl
-              }
+  query PartialSdlQuery($serviceId: ID!, $graphVariant: String!) {
+    service(id: $serviceId) {
+      implementingServices(graphVariant: $graphVariant) {
+        ... on FederatedImplementingServices {
+          services {
+            name
+            activePartialSchema {
+              sdl
             }
           }
         }
@@ -47,26 +55,35 @@ const partialSdlQuery = gql`
 export default function LoadFromAgm({ dispatch }: Props) {
   const [apiKey, updateApiKey] = useState("");
 
-  useEffect(() => {
-    const keyFromStorage = localStorage.getItem("workbenchApiKey");
-    if (keyFromStorage) updateApiKey(keyFromStorage);
-  }, []);
-
-  const [sendVariantsQuery, variantResponse] = useLazyQuery(variantsQuery);
+  const [sendGraphsQuery, { loading, data: graphs }] = useLazyQuery(
+    graphSelectQuery
+  );
   const [sendPartialSdlQuery, sdlResponse] = useLazyQuery(partialSdlQuery);
 
   useEffect(() => {
-    console.log("effect!");
-    if (sdlResponse.data) {
-      console.log(sdlResponse.data);
-      for (const {
-        name,
-        activePartialSchema: { sdl },
-      } of sdlResponse.data.me.implementingServices.services) {
-        dispatch({ type: "addService", payload: { name } });
-        dispatch({ type: "updateService", payload: { name, value: sdl } });
-        dispatch({ type: "refreshComposition"});
-      }
+    const keyFromStorage = localStorage.getItem("workbenchApiKey");
+    if (keyFromStorage) {
+      updateApiKey(keyFromStorage);
+    }
+    sendGraphsQuery();
+  }, []);
+
+  useEffect(() => {
+    if (sdlResponse.data?.service.implementingServices) {
+      dispatch({
+        type: "loadFromAGM",
+        payload: {
+          services: Object.fromEntries(
+            sdlResponse.data?.service.implementingServices.services.map(
+              (service: {
+                name: string;
+                activePartialSchema: { sdl: string };
+              }) => [service.name, service.activePartialSchema.sdl]
+            )
+          ),
+        },
+      });
+      dispatch({ type: "refreshComposition" });
     }
   }, [sdlResponse]);
 
@@ -77,14 +94,14 @@ export default function LoadFromAgm({ dispatch }: Props) {
         onSubmit={(e) => {
           e.preventDefault();
           localStorage.setItem("workbenchApiKey", apiKey);
-          sendVariantsQuery();
+          sendGraphsQuery();
         }}
       >
         <label className="LoadFromAgm-label">
-          Service API Key
+          User API Key
           <input
             className="LoadFromAgm-input"
-            placeholder="service:xyz"
+            placeholder="user:xyz"
             onChange={(e) => updateApiKey(e.target.value)}
             value={apiKey}
           />
@@ -93,21 +110,28 @@ export default function LoadFromAgm({ dispatch }: Props) {
           Load from AGM
         </Button>
       </form>
-      {!variantResponse.loading && variantResponse.data?.me && (
+      {!loading && graphs && (
         <select
           onChange={(e) => {
-            console.log("change", e.target.value);
-            sendPartialSdlQuery({
-              variables: { graphVariant: e.target.value },
-            });
+            const [serviceId, graphVariant] = e.target.value.split(",");
+            sendPartialSdlQuery({ variables: { serviceId, graphVariant } });
           }}
         >
-          <option value="">select a variant</option>
-          {variantResponse.data.me.schemaTags.map(({ variant }: any) => (
-            <option value={variant.name} key={variant.id}>
-              {variant.name}
-            </option>
-          ))}
+          <option value="">select a graph</option>
+          {graphs.me.memberships.map((membership: any) =>
+            membership.account.services.map((service: any) => (
+              <optgroup label={service.name} key={service.id}>
+                {service.schemaTags.map((schemaTag: any) => (
+                  <option
+                    key={`${service.name}@${schemaTag.variant.name}`}
+                    value={[service.name, schemaTag.variant.name]}
+                  >
+                    {schemaTag.variant.name}
+                  </option>
+                ))}
+              </optgroup>
+            ))
+          )}
         </select>
       )}
     </>

--- a/src/LoadFromAgm.tsx
+++ b/src/LoadFromAgm.tsx
@@ -66,7 +66,7 @@ export default function LoadFromAgm({ dispatch }: Props) {
       updateApiKey(keyFromStorage);
     }
     sendGraphsQuery();
-  }, []);
+  }, [sendGraphsQuery]);
 
   useEffect(() => {
     if (sdlResponse.data?.service.implementingServices) {
@@ -85,7 +85,7 @@ export default function LoadFromAgm({ dispatch }: Props) {
       });
       dispatch({ type: "refreshComposition" });
     }
-  }, [sdlResponse]);
+  }, [dispatch, sdlResponse]);
 
   return (
     <>

--- a/src/SaveAndLoad.tsx
+++ b/src/SaveAndLoad.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  Dispatch,
-  useCallback,
-  FunctionComponent,
-  Component,
-} from "react";
+import React, { useState, Dispatch, useCallback } from "react";
 import { Button } from "@apollo/space-kit/Button";
 import { colors } from "@apollo/space-kit/colors";
 import { Action } from "./App";
@@ -17,27 +11,30 @@ type Props = {
 
 // TODO: Refactor into separate file some day
 const FileUploadZone = function ({ dispatch }: Props) {
-  const onDrop = useCallback((acceptedFiles) => {
-    acceptedFiles.forEach((file: FileWithPath) => {
-      const reader = new FileReader();
-      // We have to use a FileReader to get the contents of the file
-      reader.onabort = () => console.warn("file reading was aborted");
-      reader.onerror = () => console.warn("file reading has failed");
-      reader.onload = () => {
-        const textString = "" + reader.result;
-        console.log(textString?.toString());
-        // Try to load
-        dispatch({ type: "loadWorkbench", payload: textString });
-        dispatch({ type: "refreshComposition" });
-      };
-      reader.readAsText(file);
-    });
-  }, []);
+  const onDrop = useCallback(
+    (acceptedFiles) => {
+      acceptedFiles.forEach((file: FileWithPath) => {
+        const reader = new FileReader();
+        // We have to use a FileReader to get the contents of the file
+        reader.onabort = () => console.warn("file reading was aborted");
+        reader.onerror = () => console.warn("file reading has failed");
+        reader.onload = () => {
+          const textString = "" + reader.result;
+          console.log(textString?.toString());
+          // Try to load
+          dispatch({ type: "loadWorkbench", payload: textString });
+          dispatch({ type: "refreshComposition" });
+        };
+        reader.readAsText(file);
+      });
+    },
+    [dispatch]
+  );
   const { getRootProps, getInputProps } = useDropzone({
     accept: ".federationworkbench",
     onDrop,
   });
-  
+
   return (
     <section className="dropzone-container">
       <div {...getRootProps({ className: "dropzone-item" })}>

--- a/src/editors/ServiceEditors.tsx
+++ b/src/editors/ServiceEditors.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch } from "react";
 import { ControlledEditor } from "@monaco-editor/react";
 import { Action } from "../App";
 import "./ServiceEditors.css";
-import {debounce} from "../utils/debounce";
+import { debounce } from "../utils/debounce";
 
 type Props = {
   dispatch: Dispatch<Action>;
@@ -11,17 +11,12 @@ type Props = {
   composition: string | undefined;
 };
 
-function handleEditorDidMount(_: any, editor: any) {
-  editor.updateOptions({ readOnly: true });
-}
-
 export default function ServiceEditors({
   dispatch,
   services,
   selectedService,
   composition,
 }: Props) {
-
   const updateService = debounce((e: Event, name: string, value: any) => {
     console.log("Updating service...");
     dispatch({
@@ -30,8 +25,8 @@ export default function ServiceEditors({
     });
     //TODO: Debounce within Debounce? 🤔
     dispatch({
-      type: 'refreshComposition'
-    })
+      type: "refreshComposition",
+    });
   }, 2000);
 
   return (
@@ -67,7 +62,10 @@ export default function ServiceEditors({
           theme="dark"
           language="graphql"
           value={composition}
-          //   editorDidMount={handleEditorDidMount}
+          // TODO: this editor should be read-only. For breadcrumbs, the below worked previously.
+          // editorDidMount={(_: any, editor: any) => {
+          //   editor.updateOptions({ readOnly: true });
+          // }}
         />
       </div>
     </div>


### PR DESCRIPTION
This adds support for user tokens, giving the user a dropdown
for all of their available graph+variant combinations.

Unfortunately, this list is unfiltered, meaning not just federated
graphs show up. In order to filter this list we'd need to overfetch
or adjust the schema to our needs. For now, nothing happens if you
select a non-federated service.